### PR TITLE
Fix remaining hardcoded autocast device_type in forward_ffn

### DIFF
--- a/recipe/fix_hardcoded_cuda_device.patch
+++ b/recipe/fix_hardcoded_cuda_device.patch
@@ -2,7 +2,17 @@ diff --git a/sam3/model/decoder.py b/sam3/model/decoder.py
 index 7a204be..a103c71 100644
 --- a/sam3/model/decoder.py
 +++ b/sam3/model/decoder.py
-@@ -214,6 +214,7 @@ class TransformerDecoder(nn.Module):
+@@ -68,7 +68,8 @@ class TransformerDecoderLayer(nn.Module):
+         return tensor if pos is None else tensor + pos
+
+     def forward_ffn(self, tgt):
+-        with torch.amp.autocast(device_type="cuda", enabled=False):
++        device_type = tgt.device.type if tgt.device.type != "mps" else "cpu"
++        with torch.amp.autocast(device_type=device_type, enabled=False):
+             tgt2 = self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
+         tgt = tgt + self.dropout4(tgt2)
+         tgt = self.norm3(tgt)
+@@ -214,6 +215,7 @@ class TransformerDecoder(nn.Module):
          separate_norm_instance: bool = False,
          resolution: Optional[int] = None,
          stride: Optional[int] = None,

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -38,7 +38,7 @@ source:
     - fix_hardcoded_cuda_device.patch
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script:
     - python -m pip install . -vv


### PR DESCRIPTION
## Summary
- #7 fixed most hardcoded `device="cuda"` occurrences, but `TransformerDecoderLayer.forward_ffn` still had `torch.amp.autocast(device_type="cuda")` hardcoded
- Updated `fix_hardcoded_cuda_device.patch` to derive `device_type` from the input tensor at runtime, with MPS fallback to `"cpu"` since `torch.amp.autocast` does not support MPS

Upstream fix: https://github.com/facebookresearch/sam3/pull/482