### PR TITLE
Patch sam3 to use non-deprecated timm.layers import path

### DIFF
--- a/recipe/fix_timm_models_layers_import.patch
+++ b/recipe/fix_timm_models_layers_import.patch
@@ -1,0 +1,18 @@
+diff --git a/sam3/model/video_tracking_multiplex.py b/sam3/model/video_tracking_multiplex.py
+index 0000000..1111111 100644
+--- a/sam3/model/video_tracking_multiplex.py
++++ b/sam3/model/video_tracking_multiplex.py
+@@ -41,7 +41,12 @@
+ from sam3.sam.mask_decoder import MaskDecoder
+ from sam3.sam.prompt_encoder import PositionEmbeddingRandom, PromptEncoder
+ from sam3.sam.transformer import TwoWayTransformer
+-from timm.models.layers import trunc_normal_
++
++try:
++    from timm.layers import trunc_normal_
++except ModuleNotFoundError:
++    # compatibility for older timm versions
++    from timm.models.layers import trunc_normal_
+
+
+ # a large negative value as a placeholder score for missing objects

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -36,9 +36,12 @@ source:
     - fix_pkg_resources.patch
     # Fix hardcoded device="cuda" that prevents loading on CPU/macOS
     - fix_hardcoded_cuda_device.patch
+    # Use the non-deprecated `timm.layers` import path, consistent with the
+    # try/except guard the other sam3 modules already use
+    - fix_timm_models_layers_import.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - python -m pip install . -vv


### PR DESCRIPTION
<details><summary>Claude's draft</summary>

`sam3/model/video_tracking_multiplex.py` imports `trunc_normal_` directly from `timm.models.layers`, which emits a `FutureWarning` on timm >= 1.0 ("Importing from timm.models.layers is deprecated, please import via timm.layers").

Add `fix_timm_models_layers_import.patch` to switch it to the `try: from timm.layers ... except ModuleNotFoundError: from timm.models.layers ...` guard already used by the other sam3 modules (sam3_tracker_base.py, memory.py, vitdet.py).

Bump the build number to 1.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume b3d74626-2bde-434a-9ef4-b5d37c38a851
```
</details>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
