### PR TITLE
Remove 3-channel input assertion to allow grayscale input

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -52,9 +52,12 @@ source:
     #   https://github.com/facebookresearch/sam3/pull/264 (rope.py + transformer)
     # Drop this patch once either lands upstream and the git_hash is bumped.
     - fix_mps_compatibility.patch
+    # Remove the 3-channel assertion in set_image / set_image_batch so
+    # downstream callers can use 1-channel input.
+    - remove_channel_assertion.patch
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script:
     - python -m pip install . -vv

--- a/recipe/remove_channel_assertion.patch
+++ b/recipe/remove_channel_assertion.patch
@@ -1,0 +1,22 @@
+--- a/sam3/model/sam1_task_predictor.py
++++ b/sam3/model/sam1_task_predictor.py
+@@ -94,9 +94,6 @@
+         input_image = self._transforms(image)
+         input_image = input_image[None, ...].to(self.device)
+ 
+-        assert len(input_image.shape) == 4 and input_image.shape[1] == 3, (
+-            f"input_image must be of size 1x3xHxW, got {input_image.shape}"
+-        )
+         logging.info("Computing image embeddings for the provided image...")
+         backbone_out = self.model.forward_image(input_image)
+         (
+@@ -141,9 +138,6 @@
+         img_batch = self._transforms.forward_batch(image_list)
+         img_batch = img_batch.to(self.device)
+         batch_size = img_batch.shape[0]
+-        assert len(img_batch.shape) == 4 and img_batch.shape[1] == 3, (
+-            f"img_batch must be of size Bx3xHxW, got {img_batch.shape}"
+-        )
+         logging.info("Computing image embeddings for the provided images...")
+         backbone_out = self.model.forward_image(img_batch)
+         (


### PR DESCRIPTION
Remove the 3-channel assertion in `set_image` / `set_image_batch` so downstream callers can use 1-channel input.