### PR TITLE
move away torch.jit due to warning

### DIFF
--- a/recipe/avoid_deprecated_torch_jit_script.patch
+++ b/recipe/avoid_deprecated_torch_jit_script.patch
@@ -1,0 +1,51 @@
+diff --git a/sam3/model/box_ops.py b/sam3/model/box_ops.py
+index 59f52e0..339187e 100644
+--- a/sam3/model/box_ops.py
++++ b/sam3/model/box_ops.py
+@@ -144,7 +144,6 @@ def generalized_box_iou(boxes1, boxes2):
+     return iou - (area - union) / area
+ 
+ 
+-@torch.jit.script
+ def fast_diag_generalized_box_iou(boxes1, boxes2):
+     assert len(boxes1) == len(boxes2)
+     box1_xy = boxes1[:, 2:]
+@@ -171,7 +170,6 @@ def fast_diag_generalized_box_iou(boxes1, boxes2):
+     return iou - (tot_area - union) / tot_area
+ 
+ 
+-@torch.jit.script
+ def fast_diag_box_iou(boxes1, boxes2):
+     assert len(boxes1) == len(boxes2)
+     box1_xy = boxes1[:, 2:]
+diff --git a/sam3/model/utils/sam1_utils.py b/sam3/model/utils/sam1_utils.py
+index 1ee131e..d6de5bc 100644
+--- a/sam3/model/utils/sam1_utils.py
++++ b/sam3/model/utils/sam1_utils.py
+@@ -30,11 +30,9 @@ class SAM2Transforms(nn.Module):
+         self.mean = [0.5, 0.5, 0.5]
+         self.std = [0.5, 0.5, 0.5]
+         self.to_tensor = ToTensor()
+-        self.transforms = torch.jit.script(
+-            nn.Sequential(
+-                Resize((self.resolution, self.resolution)),
+-                Normalize(self.mean, self.std),
+-            )
++        self.transforms = nn.Sequential(
++            Resize((self.resolution, self.resolution)),
++            Normalize(self.mean, self.std),
+         )
+ 
+     def __call__(self, x):
+diff --git a/sam3/train/loss/loss_fns.py b/sam3/train/loss/loss_fns.py
+index 8fa1774..e22db00 100644
+--- a/sam3/train/loss/loss_fns.py
++++ b/sam3/train/loss/loss_fns.py
+@@ -195,7 +195,6 @@ def iou_loss(
+     return loss.sum() / num_boxes
+ 
+ 
+-@torch.jit.script
+ def _contrastive_align(logits, positive_map):
+     positive_logits = -logits.masked_fill(~positive_map, 0)
+     negative_logits = logits  # .masked_fill(positive_map, -1000000)

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,7 +9,6 @@ context:
   git_hash_date: "20260515"
   git_hash: "32f5f81ab9eef0ef3bd33be4d2af31e350ae64ef"
   version: 0.1.0.${{ git_hash_date }}
-  python_min: "3.10"
 
 
 package:
@@ -97,7 +96,9 @@ tests:
       imports:
         - sam3
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       # Verify the BPE vocabulary asset is included in the package
       - test -f $PREFIX/lib/python*/site-packages/sam3/assets/bpe_simple_vocab_16e6.txt.gz

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -55,9 +55,15 @@ source:
     # Remove the 3-channel assertion in set_image / set_image_batch so
     # downstream callers can use 1-channel input.
     - remove_channel_assertion.patch
+    # torch.jit.script is deprecated (torch >=2.9 emits a DeprecationWarning on
+    # every call) and the scripted callables here are plain eager helpers:
+    # the two box IoU functions, the contrastive align loss, and the
+    # Resize + Normalize Sequential rebuilt on every image predictor.
+    # Scripting that Sequential alone emits ~29 warnings per predictor.
+    - avoid_deprecated_torch_jit_script.patch
 
 build:
-  number: 4
+  number: 5
   noarch: python
   script:
     - python -m pip install . -vv


### PR DESCRIPTION
`torch.jit.script` is deprecated in recent PyTorch and warns on every call. The scripted callables here are plain eager helpers (two box IoU functions, the contrastive align loss, and the `Resize`+`Normalize` `Sequential` rebuilt for every image predictor — that one alone emits ~29 deprecation warnings per predictor), so drop the scripting.

Verified numerics are unchanged for the box IoU helpers and the transform output shape, and that the patches still apply in order.

Build number bumped.